### PR TITLE
re-sync with main

### DIFF
--- a/bin/tomoscan
+++ b/bin/tomoscan
@@ -11,6 +11,7 @@ import argparse
 import time
 import shutil
 import pathlib
+import json
 import numpy as np
 from datetime import datetime
 
@@ -23,25 +24,44 @@ import epics
 def init_PVs(tomoscan_prefix):
     
     ts_pvs = {}
-    file_plugin_prefix = epics.caget(tomoscan_prefix + 'FilePluginPVPrefix')    
+    file_plugin_prefix              = epics.caget(tomoscan_prefix + 'FilePluginPVPrefix')    
+    
+    sample_x_pv_name                = PV(tomoscan_prefix + 'SampleXPVName').value
+    sample_y_pv_name                = PV(tomoscan_prefix + 'SampleYPVName').value
+    ts_pvs['SampleX']               = PV(sample_x_pv_name)
+    ts_pvs['SampleY']               = PV(sample_y_pv_name)
 
-    ts_pvs['StartScan'] = PV(tomoscan_prefix + 'StartScan')
-    ts_pvs['ServerRunning'] = PV(tomoscan_prefix + 'ServerRunning')
-    ts_pvs['ScanStatus'] = PV(tomoscan_prefix + 'ScanStatus')
-    ts_pvs['SampleName'] = PV(tomoscan_prefix + 'SampleName')
-    ts_pvs['SampleInX'] = PV(tomoscan_prefix + 'SampleInX')
-    ts_pvs['SampleInY'] = PV(tomoscan_prefix + 'SampleInY')
-    ts_pvs['FlatFieldAxis'] = PV(tomoscan_prefix + 'FlatFieldAxis')
-    ts_pvs['FlatFieldMode'] = PV(tomoscan_prefix + 'FlatFieldMode')
-    ts_pvs['FileName'] = PV(tomoscan_prefix + 'FileName')
-    ts_pvs['FileTemplate'] = PV(file_plugin_prefix + 'FileTemplate')
-    ts_pvs['FileNumber'] = PV(file_plugin_prefix + 'FileNumber')
+    ts_pvs['StartScan']             = PV(tomoscan_prefix + 'StartScan')
+    ts_pvs['ServerRunning']         = PV(tomoscan_prefix + 'ServerRunning')
+    ts_pvs['ScanStatus']            = PV(tomoscan_prefix + 'ScanStatus')
+    ts_pvs['SampleName']            = PV(tomoscan_prefix + 'SampleName')
 
-    sample_x_pv_name = PV(tomoscan_prefix + 'SampleXPVName').value
-    sample_y_pv_name  = PV(tomoscan_prefix + 'SampleYPVName').value
+    ts_pvs['FileName']              = PV(tomoscan_prefix + 'FileName')
+    ts_pvs['FileTemplate']          = PV(file_plugin_prefix + 'FileTemplate')
+    ts_pvs['FileNumber']            = PV(file_plugin_prefix + 'FileNumber')
 
-    ts_pvs['SampleX'] = PV(sample_x_pv_name)
-    ts_pvs['SampleY'] = PV(sample_y_pv_name)
+    ts_pvs['RotationStart']         = PV(tomoscan_prefix + 'RotationStart')  
+    ts_pvs['RotationStep']          = PV(tomoscan_prefix + 'RotationStep')  
+    ts_pvs['NumAngles']             = PV(tomoscan_prefix + 'NumAngles')  
+    ts_pvs['ReturnRotation']        = PV(tomoscan_prefix + 'ReturnRotation')  
+    ts_pvs['NumDarkFields']         = PV(tomoscan_prefix + 'NumDarkFields')  
+    ts_pvs['DarkFieldMode']         = PV(tomoscan_prefix + 'DarkFieldMode')  
+    ts_pvs['DarkFieldValue']        = PV(tomoscan_prefix + 'DarkFieldValue')  
+    ts_pvs['NumFlatFields']         = PV(tomoscan_prefix + 'NumFlatFields')
+    ts_pvs['FlatFieldAxis']         = PV(tomoscan_prefix + 'FlatFieldAxis')
+    ts_pvs['FlatFieldMode']         = PV(tomoscan_prefix + 'FlatFieldMode')
+    ts_pvs['FlatFieldValue']        = PV(tomoscan_prefix + 'FlatFieldValue')  
+    ts_pvs['FlatExposureTime']      = PV(tomoscan_prefix + 'FlatExposureTime')  
+    ts_pvs['DifferentFlatExposure'] = PV(tomoscan_prefix + 'DifferentFlatExposure')
+    ts_pvs['SampleInX']             = PV(tomoscan_prefix + 'SampleInX')
+    ts_pvs['SampleOutX']            = PV(tomoscan_prefix + 'SampleOutX')  
+    ts_pvs['SampleInY']             = PV(tomoscan_prefix + 'SampleInY')
+    ts_pvs['SampleOutY']            = PV(tomoscan_prefix + 'SampleOutY')  
+    ts_pvs['SampleOutAngleEnable']  = PV(tomoscan_prefix + 'SampleOutAngleEnable') 
+    ts_pvs['SampleOutAngle']        = PV(tomoscan_prefix + 'SampleOutAngle')  
+    ts_pvs['ScanType']              = PV(tomoscan_prefix + 'ScanType')
+    ts_pvs['FlipStitch']            = PV(tomoscan_prefix + 'FlipStitch')
+    ts_pvs['ExposureTime']          = PV(tomoscan_prefix + 'ExposureTime')
 
     return ts_pvs
 
@@ -52,34 +72,99 @@ def init(args):
     else:
         log.error("{0} already exists".format(args.config))
 
+    ts_pvs = init_PVs(args.tomoscan_prefix)
+    scan_dict = {}
+
+    RotationStart         = ts_pvs['RotationStart'].get() 
+    RotationStep          = ts_pvs['RotationStep'].get()  
+    NumAngles             = ts_pvs['NumAngles'].get() 
+    ReturnRotation        = ts_pvs['ReturnRotation'].get() 
+    NumDarkFields         = ts_pvs['NumDarkFields'].get() 
+    DarkFieldMode         = ts_pvs['DarkFieldMode'].get(as_string=True) 
+    DarkFieldValue        = ts_pvs['DarkFieldValue'].get() 
+    NumFlatFields         = ts_pvs['NumFlatFields'].get() 
+    FlatFieldAxis         = ts_pvs['FlatFieldAxis'].get(as_string=True) 
+    FlatFieldMode         = ts_pvs['FlatFieldMode'].get(as_string=True) 
+    FlatFieldValue        = ts_pvs['FlatFieldValue'].get() 
+    FlatExposureTime      = ts_pvs['FlatExposureTime'].get() 
+    DifferentFlatExposure = ts_pvs['DifferentFlatExposure'].get(as_string=True) 
+    SampleInX             = ts_pvs['SampleInX'].get() 
+    SampleOutX            = ts_pvs['SampleOutX'].get() 
+    SampleInY             = ts_pvs['SampleInY'].get() 
+    SampleOutY            = ts_pvs['SampleOutY'].get() 
+    SampleOutAngleEnable  = ts_pvs['SampleOutAngleEnable'].get(as_string=True) 
+    SampleOutAngle        = ts_pvs['SampleOutAngle'].get() 
+    ScanType              = ts_pvs['ScanType'].get(as_string=True) 
+    FlipStitch            = ts_pvs['FlipStitch'].get(as_string=True) 
+    ExposureTime          = ts_pvs['ExposureTime'].get()
+
+    for x in range(args.num_scans):
+        key = str(x).zfill(3)
+        scan_dict[key] =  {'SampleX' : 0.0,  
+                           'SampleY' : 0.0,  
+                           'RotationStart'         : RotationStart, 
+                           'RotationStep'          : RotationStep,  
+                           'NumAngles'             : NumAngles, 
+                           'ReturnRotation'        : ReturnRotation, 
+                           'NumDarkFields'         : NumDarkFields, 
+                           'DarkFieldMode'         : DarkFieldMode, 
+                           'DarkFieldValue'        : DarkFieldValue, 
+                           'NumFlatFields'         : NumFlatFields, 
+                           'FlatFieldAxis'         : FlatFieldAxis, 
+                           'FlatFieldMode'         : FlatFieldMode, 
+                           'FlatFieldValue'        : FlatFieldValue, 
+                           'FlatExposureTime'      : FlatExposureTime, 
+                           'DifferentFlatExposure' : DifferentFlatExposure, 
+                           'SampleInX'             : SampleInX, 
+                           'SampleOutX'            : SampleOutX, 
+                           'SampleInY'             : SampleInY, 
+                           'SampleOutY'            : SampleOutY, 
+                           'SampleOutAngleEnable'  : SampleOutAngleEnable, 
+                           'SampleOutAngle'        : SampleOutAngle, 
+                           'ScanType'              : ScanType, 
+                           'FlipStitch'            : FlipStitch, 
+                           'ExposureTime'          : ExposureTime
+                           }
+
+    with open(args.scan_file, 'w') as fp:
+        json.dump(scan_dict, fp, indent=4, sort_keys=True)
+
+    log.info('For arbitrary scans location custormize (SampleX, SampleY) in {0}'.format(args.scan_file))
+
 def run_status(args):
     config.show_config(args)
 
 def run_single(args):
-    args.scan_type = 'single'
-
+    args.scan_type = 'Single'
     run_scan(args)
     config.write(args.config, args, sections=config.SINGLE_SCAN_PARAMS)
 
 def run_vertical(args):
-    args.scan_type = 'vertical'
+    args.scan_type = 'Vertical'
     run_scan(args)
     config.write(args.config, args, sections=config.VERTICAL_SCAN_PARAMS)
 
 def run_horizontal(args):
-    args.scan_type = 'horizontal'
+    args.scan_type = 'Horizontal'
     run_scan(args)
     config.write(args.config, args, sections=config.HORIZONTAL_SCAN_PARAMS)
 
 def run_mosaic(args):
-    args.scan_type = 'mosaic'
+    args.scan_type = 'Mosaic'
     run_scan(args)
     config.write(args.config, args, sections=config.MOSAIC_SCAN_PARAMS)
 
 def run_energy(args):
-    args.scan_type = 'energy'
+    args.scan_type = 'Energy'
     run_scan(args)
     config.write(args.config, args, sections=config.ENERGY_SCAN_PARAMS)    
+
+def run_file(args):
+
+    args.scan_type = 'File'
+    run_scan(args)
+    config.write(args.config, args, sections=config.ENERGY_SCAN_PARAMS)    
+
 
 def run_scan(args):
     
@@ -88,6 +173,7 @@ def run_scan(args):
     if ts_pvs['ServerRunning'].get():
         if ts_pvs['ScanStatus'].get(as_string=True) == 'Scan complete':
             log.warning('%s scan start', args.scan_type)
+            ts_pvs['ScanType'].put(args.scan_type, wait=True)
             if (args.sleep_steps >= 1) and (args.sleep == True):
                 log.warning('running %d x %2.2fs sleep scans', args.sleep_steps, args.sleep_time)
                 tic =  time.time()
@@ -108,6 +194,7 @@ def run_scan(args):
             else:
                 scan(args, ts_pvs)
             log.warning('%s scan end', args.scan_type)
+            ts_pvs['ScanType'].put('Single', wait=True)
         else:
             log.error('Server %s is busy. Please run a scan manually first.', args.tomoscan_prefix)
     else:
@@ -118,11 +205,13 @@ def scan(args, ts):
     tic_01 =  time.time()
     flat_field_axis = ts['FlatFieldAxis'].get(as_string=True)
     flat_field_mode = ts['FlatFieldMode'].get(as_string=True)
-    if (args.scan_type == 'single'):
+    if (args.scan_type == 'Single'):
         single_scan(args, ts)
-    elif (args.scan_type == 'energy'):
+    elif (args.scan_type == 'File'):
+        file_scan(args, ts)   
+    elif (args.scan_type == 'Energy'):
         energy_scan(args, ts)        
-    elif (args.scan_type == 'mosaic'):
+    elif (args.scan_type == 'Mosaic'):
         start_y = args.vertical_start
         step_size_y = args.vertical_step_size  
         steps_y = args.vertical_steps
@@ -153,7 +242,7 @@ def scan(args, ts):
         dtime = (time.time() - tic_01)/60.
         log.info('%s scan time: %3.3f minutes', args.scan_type, dtime)
     else:
-        if (args.scan_type == 'horizontal'):
+        if (args.scan_type == 'Horizontal'):
             start = args.horizontal_start
             step_size = args.horizontal_step_size       
             steps = args.horizontal_steps
@@ -163,7 +252,7 @@ def scan(args, ts):
                 pv = "SampleX"
             else:
                 pv = "SampleInX"
-        elif (args.scan_type == 'vertical'):
+        elif (args.scan_type == 'Vertical'):
             start = args.vertical_start
             step_size = args.vertical_step_size
             steps = args.vertical_steps
@@ -179,6 +268,8 @@ def scan(args, ts):
             single_scan(args, ts)
         dtime = (time.time() - tic_01)/60.
         log.info('%s scan time: %3.3f minutes', args.scan_type, dtime)
+
+    ts['ScanType'].put('Single', wait=True)
 
 def single_scan(args, ts):
 
@@ -263,6 +354,73 @@ def energy_scan(args, ts):
             
     dtime = (time.time() - tic_01)/60.
     log.info('energy scan time: %3.3f minutes', dtime)
+    ts['ScanType'].put('Single', wait=True)
+
+
+def file_scan(args, ts):
+
+    tic_01 =  time.time()
+    log.info('file scan start')
+
+    try:
+        with open(args.scan_file) as json_file:
+            scan_dict = json.load(json_file)
+    except FileNotFoundError:
+        log.error('File %s not found', args.scan_file)
+        exit()
+    except:
+        log.error('File %s is not correcly formatted', args.scan_file)
+        exit()
+    flat_field_axis = ts['FlatFieldAxis'].get(as_string=True)
+    flat_field_mode = ts['FlatFieldMode'].get(as_string=True)
+
+    for key, value in scan_dict.items():
+
+
+        ts['SampleX'].put(value['SampleX'], wait=True)
+        ts['SampleY'].put(value['SampleY'], wait=True)
+        ts['RotationStart'].put(value['RotationStart'], wait=True) 
+        ts['RotationStep'].put(value['RotationStep'], wait=True)
+        ts['NumAngles'].put(value['NumAngles'], wait=True) 
+        ts['ReturnRotation'].put(value['ReturnRotation'], wait=True) 
+        ts['NumDarkFields'].put(value['NumDarkFields'], wait=True) 
+        ts['DarkFieldMode'].put(value['DarkFieldMode'], wait=True) 
+        ts['DarkFieldValue'].put(value['DarkFieldValue'], wait=True) 
+        ts['NumFlatFields'].put(value['NumFlatFields'], wait=True) 
+        ts['FlatFieldAxis'].put(value['FlatFieldAxis'], wait=True) 
+        ts['FlatFieldMode'].put(value['FlatFieldMode'], wait=True) 
+        ts['FlatFieldValue'].put(value['FlatFieldValue'], wait=True) 
+        ts['FlatExposureTime'].put(value['FlatExposureTime'], wait=True) 
+        ts['DifferentFlatExposure'].put(value['DifferentFlatExposure'], wait=True) 
+        ts['SampleInX'].put(value['SampleInX'], wait=True) 
+        ts['SampleOutX'].put(value['SampleOutX'], wait=True) 
+        ts['SampleInY'].put(value['SampleInY'], wait=True) 
+        ts['SampleOutY'].put(value['SampleOutY'], wait=True) 
+        ts['SampleOutAngleEnable'].put(value['SampleOutAngleEnable'], wait=True) 
+        ts['SampleOutAngle'].put(value['SampleOutAngle'], wait=True) 
+        ts['ScanType'].put(value['ScanType'], wait=True) 
+        ts['FlipStitch'].put(value['FlipStitch'], wait=True) 
+        ts['ExposureTime'].put(value['ExposureTime'], wait=True)
+
+        log.warning('Scan key/number: %s ', key)
+        log.warning('%s stage position: %3.3f mm', 'Sample Y', value['SampleY'])
+        log.warning('%s stage position: %3.3f mm', 'Sample X', value['SampleX'])
+        if flat_field_axis in ('X') or flat_field_mode == 'None':
+            pv_y = "SampleY"
+        else:
+            pv_y = "SampleInY"
+        ts[pv_y].put(value['SampleY'], wait=True)
+        if flat_field_axis in ('Y') or flat_field_mode == 'None':
+            pv_x = "SampleX"
+        else:
+            pv_x = "SampleInX"
+        ts[pv_x].put(value['SampleX'], wait=True, timeout=600)
+        # single_scan(args, ts)
+        # config.write(args.config, args, sections=config.SINGLE_SCAN_PARAMS)
+
+    dtime = (time.time() - tic_01)/60.
+    log.info('file scan time: %3.3f minutes', dtime)
+    ts['ScanType'].put('Single', wait=True)
 
 def main():
     # set logs directory
@@ -280,20 +438,23 @@ def main():
     parser.add_argument('--version', action='version',
                         version='%(prog)s {}'.format(__version__))
 
-    single_param = config.SINGLE_SCAN_PARAMS
-    vertical_param = config.VERTICAL_SCAN_PARAMS
+    init_param       = config.INIT_PARAMS
+    single_param     = config.SINGLE_SCAN_PARAMS
+    vertical_param   = config.VERTICAL_SCAN_PARAMS
     horizontal_param = config.HORIZONTAL_SCAN_PARAMS
-    mosaic_param = config.MOSAIC_SCAN_PARAMS
-    energy_param = config.ENERGY_SCAN_PARAMS
+    mosaic_param     = config.MOSAIC_SCAN_PARAMS
+    energy_param     = config.ENERGY_SCAN_PARAMS
+    file_param       = config.FILE_SCAN_PARAMS
 
     cmd_parsers = [
-        ('init',           init,              (),                   "Create configuration file"),
+        ('init',           init,              init_param,           "Create configuration file"),
         ('status',         run_status,        mosaic_param,         "Show tomoscan status"),
         ('single',         run_single,        single_param,         "Run a single tomographic scan"),
         ('vertical',       run_vertical,      vertical_param,       "Run a vertical tomographic scan"),
         ('horizontal',     run_horizontal,    horizontal_param,     "Run a horizontal tomographic scan"),
         ('mosaic',         run_mosaic,        mosaic_param,         "Run a mosaic tomographic scan"),
         ('energy',         run_energy,        energy_param,         "Run an energy tomographic scan"),
+        ('file',           run_file,          file_param,           "Run a series of scans using the position stored in a configuration file"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')

--- a/docs/source/tomoScanApp.rst
+++ b/docs/source/tomoScanApp.rst
@@ -352,6 +352,24 @@ Scan status via Channel Access
       It is controlled by a watchdog timer, and will change from ``Running`` to ``Stopped``
       within 5 seconds if the Python server exits.
 
+Scan Types
+----------
+
+.. cssclass:: table-bordered table-striped table-hover
+.. list-table::
+  :header-rows: 1
+  :widths: 5 5 90
+
+  * - Record name
+    - Record type
+    - Description
+  * - $(P)$(R)ScanType
+    - mbbo
+    - Contains the scan type, e.g. 'Single', 'Vertical', 'Horizontal', 'Mosaic', "File', 'Energy', "Helical'.
+  * - $(P)$(R)FlipStitch
+    - bo
+    - Tells if the scan is a Flip&Stitch or not.
+
 tomoScan_settings.req
 ---------------------
 
@@ -889,6 +907,23 @@ Fast shutter control
   * - $(P)$(R)OpenFastShutterValue
     - stringout
     - Contains the value to write to open the fast shutter
+
+
+
+mctOptics
+^^^^^^^^^
+
+.. cssclass:: table-bordered table-striped table-hover
+.. list-table::
+  :header-rows: 1
+  :widths: 5 5 90
+
+  * - Record name
+    - Record type
+    - Description
+  * - $(P)$(R)MctOpticsPVPrefix
+    - stringout
+    - Contains the prefix for the mctOptics IOC.
 
 
 Additional files that are specific to the TomoScanStream derived class used at APS beamline 2-BM:

--- a/tomoScanApp/Db/tomoScan.template
+++ b/tomoScanApp/Db/tomoScan.template
@@ -349,3 +349,32 @@ record(bi, "$(P)$(R)ServerRunning")
    field(OSV,  "NO_ALARM")
 }
 
+############
+# Scan Types
+############
+
+record(mbbo, "$(P)$(R)ScanType")
+{
+   field(ZRVL, "0")
+   field(ZRST, "Single")
+   field(ONVL, "1")
+   field(ONST, "Vertical")
+   field(TWVL, "2")
+   field(TWST, "Horizontal")
+   field(THVL, "3")
+   field(THST, "Mosaic")
+   field(FRVL, "4")
+   field(FRST, "Scan File")
+   field(FVVL, "5")
+   field(FVST, "Energy")
+   field(SXVL, "6")
+   field(SXST, "Energy File")
+   field(SVVL, "7")
+   field(SVST, "Helical")
+}
+
+record(bo, "$(P)$(R)FlipStitch")
+{
+   field(ZNAM, "No")
+   field(ONAM, "Yes")
+}

--- a/tomoScanApp/Db/tomoScan_2BM_settings.req
+++ b/tomoScanApp/Db/tomoScan_2BM_settings.req
@@ -63,3 +63,4 @@ $(P)$(R)ShutterStatusPVName
 # mctOptics
 ################
 $(P)$(R)MctOpticsPVPrefix
+

--- a/tomoScanApp/Db/tomoScan_settings.req
+++ b/tomoScanApp/Db/tomoScan_settings.req
@@ -106,3 +106,9 @@ $(P)$(R)OverwriteWarning
 #controlPV $(P)$(R)ElapsedTime
 #controlPV $(P)$(R)RemainingTime
 #controlPV $(P)$(R)Watchdog
+
+############
+# Scan Types
+############
+$(P)$(R)ScanType
+$(P)$(R)FlipStitch

--- a/tomoScanApp/op/adl/tomoScan.adl
+++ b/tomoScanApp/op/adl/tomoScan.adl
@@ -1,6 +1,6 @@
 
 file {
-	name="/local/fast/conda/tomoscan-decarlof/tomoScanApp/op/adl/tomoScan.adl"
+	name="/home/beams8/USER2BMB/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan.adl"
 	version=030111
 }
 display {
@@ -189,7 +189,7 @@ text {
 }
 rectangle {
 	object {
-		x=5
+		x=7
 		y=50
 		width=690
 		height=65
@@ -327,7 +327,7 @@ rectangle {
 menu {
 	object {
 		x=170
-		y=310
+		y=340
 		width=100
 		height=20
 	}
@@ -340,7 +340,7 @@ menu {
 text {
 	object {
 		x=15
-		y=310
+		y=340
 		width=150
 		height=20
 	}
@@ -351,9 +351,9 @@ text {
 }
 "text entry" {
 	object {
-		x=575
-		y=335
-		width=100
+		x=145
+		y=315
+		width=70
 		height=20
 	}
 	control {
@@ -366,8 +366,8 @@ text {
 }
 text {
 	object {
-		x=440
-		y=335
+		x=10
+		y=315
 		width=130
 		height=20
 	}
@@ -502,7 +502,7 @@ text {
 }
 text {
 	object {
-		x=226
+		x=225
 		y=410
 		width=100
 		height=20
@@ -514,7 +514,7 @@ text {
 }
 "text entry" {
 	object {
-		x=331
+		x=330
 		y=410
 		width=70
 		height=20
@@ -529,8 +529,8 @@ text {
 }
 text {
 	object {
-		x=380
-		y=310
+		x=415
+		y=317
 		width=190
 		height=20
 	}
@@ -542,9 +542,9 @@ text {
 }
 menu {
 	object {
-		x=575
-		y=310
-		width=100
+		x=610
+		y=317
+		width=80
 		height=20
 	}
 	control {
@@ -1127,8 +1127,8 @@ menu {
 }
 text {
 	object {
-		x=35
-		y=335
+		x=350
+		y=340
 		width=130
 		height=20
 	}
@@ -1140,8 +1140,8 @@ text {
 }
 menu {
 	object {
-		x=170
-		y=335
+		x=485
+		y=340
 		width=100
 		height=20
 	}
@@ -1153,8 +1153,8 @@ menu {
 }
 "text entry" {
 	object {
-		x=275
-		y=335
+		x=590
+		y=340
 		width=100
 		height=20
 	}
@@ -1325,4 +1325,31 @@ menu {
 		clr=14
 		bclr=51
 	}
+}
+"text entry" {
+	object {
+		x=330
+		y=315
+		width=70
+		height=20
+	}
+	control {
+		chan="$(P)$(R)FlatFieldValue"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=225
+		y=315
+		width=100
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Flat value"
 }

--- a/tomoScanApp/op/adl/tomoScanStream_2BM_otherpvs.adl
+++ b/tomoScanApp/op/adl/tomoScanStream_2BM_otherpvs.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/local/user2bmb/epics_new/synApps/support/tomoscan/iocBoot/iocTomoScan_2BMA/../../tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl"
+	name="/home/beams/USER2BMB/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl"
 	version=030111
 }
 display {
 	object {
-		x=84
-		y=691
+		x=61
+		y=879
 		width=640
-		height=240
+		height=290
 	}
 	clr=14
 	bclr=4
@@ -317,7 +317,7 @@ text {
 text {
 	object {
 		x=159
-		y=215
+		y=265
 		width=90
 		height=20
 	}
@@ -330,7 +330,7 @@ text {
 "related display" {
 	object {
 		x=254
-		y=215
+		y=265
 		width=100
 		height=20
 	}
@@ -342,4 +342,56 @@ text {
 	clr=14
 	bclr=51
 	label="PSO setup"
+}
+text {
+	object {
+		x=119
+		y=215
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Scan type"
+	align="horiz. right"
+}
+text {
+	object {
+		x=119
+		y=240
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Flip&Stitch"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=254
+		y=215
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ScanType"
+		clr=14
+		bclr=51
+	}
+}
+menu {
+	object {
+		x=254
+		y=240
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)FlipStitch"
+		clr=14
+		bclr=51
+	}
 }

--- a/tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl
+++ b/tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/local/user2bmb/epics_new/synApps/support/tomoscan/iocBoot/iocTomoScan_2BMA/../../tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl"
+	name="/home/beams8/USER2BMB/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl"
 	version=030111
 }
 display {
 	object {
-		x=84
-		y=691
+		x=61
+		y=879
 		width=640
-		height=240
+		height=290
 	}
 	clr=14
 	bclr=4
@@ -317,7 +317,7 @@ text {
 text {
 	object {
 		x=159
-		y=215
+		y=265
 		width=90
 		height=20
 	}
@@ -330,7 +330,7 @@ text {
 "related display" {
 	object {
 		x=254
-		y=215
+		y=265
 		width=100
 		height=20
 	}
@@ -342,4 +342,56 @@ text {
 	clr=14
 	bclr=51
 	label="PSO setup"
+}
+text {
+	object {
+		x=119
+		y=215
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Scan type"
+	align="horiz. right"
+}
+text {
+	object {
+		x=119
+		y=240
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Flip&Stitch"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=254
+		y=215
+		width=100
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ScanType"
+		clr=14
+		bclr=51
+	}
+}
+menu {
+	object {
+		x=254
+		y=240
+		width=100
+		height=20
+	}
+	control {
+		chan="$(P)$(R)FlipStitch"
+		clr=14
+		bclr=51
+	}
 }

--- a/tomoScanApp/op/adl/tomoScan_32ID_otherpvs.adl
+++ b/tomoScanApp/op/adl/tomoScan_32ID_otherpvs.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/local/user2bmb/epics_new/synApps/support/tomoscan/iocBoot/iocTomoScan_2BMA/../../tomoScanApp/op/adl/tomoScan_2BM_otherpvs.adl"
+	name="/home/beams8/USER2BMB/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_32ID_otherpvs.adl"
 	version=030111
 }
 display {
 	object {
-		x=84
-		y=691
+		x=724
+		y=962
 		width=640
-		height=240
+		height=290
 	}
 	clr=14
 	bclr=4
@@ -317,7 +317,7 @@ text {
 text {
 	object {
 		x=159
-		y=215
+		y=265
 		width=90
 		height=20
 	}
@@ -330,7 +330,7 @@ text {
 "related display" {
 	object {
 		x=254
-		y=215
+		y=265
 		width=100
 		height=20
 	}
@@ -342,4 +342,56 @@ text {
 	clr=14
 	bclr=51
 	label="PSO setup"
+}
+text {
+	object {
+		x=119
+		y=215
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Scan type"
+	align="horiz. right"
+}
+text {
+	object {
+		x=119
+		y=240
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Flip&Stitch"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=254
+		y=215
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ScanType"
+		clr=14
+		bclr=51
+	}
+}
+menu {
+	object {
+		x=254
+		y=240
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)FlipStitch"
+		clr=14
+		bclr=51
+	}
 }

--- a/tomoScanApp/op/adl/tomoScan_7BM_otherpvs.adl
+++ b/tomoScanApp/op/adl/tomoScan_7BM_otherpvs.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/beams9/FUELSPRAY/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_7BM_otherpvs.adl"
+	name="/home/beams8/USER2BMB/epics/synApps/support/tomoscan/tomoScanApp/op/adl/tomoScan_7BM_otherpvs.adl"
 	version=030111
 }
 display {
 	object {
-		x=1238
-		y=514
+		x=726
+		y=235
 		width=640
-		height=260
+		height=320
 	}
 	clr=14
 	bclr=4
@@ -342,4 +342,85 @@ text {
 	format="string"
 	limits {
 	}
+}
+text {
+	object {
+		x=119
+		y=245
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Scan type"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=254
+		y=245
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ScanType"
+		clr=14
+		bclr=51
+	}
+}
+menu {
+	object {
+		x=254
+		y=270
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)FlipStitch"
+		clr=14
+		bclr=51
+	}
+}
+text {
+	object {
+		x=119
+		y=270
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Flip&Stitch"
+	align="horiz. right"
+}
+text {
+	object {
+		x=159
+		y=295
+		width=90
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="PSO setup"
+	align="horiz. right"
+}
+"related display" {
+	object {
+		x=254
+		y=295
+		width=100
+		height=20
+	}
+	display[0] {
+		label="PSO setup"
+		name="tomoScan_pso.adl"
+		args="P=$(P), R=$(R)"
+	}
+	clr=14
+	bclr=51
+	label="PSO setup"
 }

--- a/tomoscan/config.py
+++ b/tomoscan/config.py
@@ -27,6 +27,7 @@ from tomoscan import __version__
 home = os.path.expanduser("~")
 LOGS_HOME = os.path.join(home, 'logs')
 CONFIG_FILE_NAME = os.path.join(home, 'tomoscan.conf')
+SCAN_FILE_NAME = os.path.join(home, 'scan.json')
 
 SECTIONS = OrderedDict()
 
@@ -34,7 +35,12 @@ SECTIONS['general'] = {
     'config': {
         'default': CONFIG_FILE_NAME,
         'type': str,
-        'help': "File name of configuration file",
+        'help': "File name of configuration file. Default: ~/tomoscan.conf",
+        'metavar': 'FILE'},
+    'scan-file': {
+        'default': SCAN_FILE_NAME,
+        'type': str,
+        'help': "File name of scan file contaning a dictionary listing multiple scan parameters. Default: ~/scan.json",
         'metavar': 'FILE'},
     'logs-home': {
         'default': LOGS_HOME,
@@ -72,7 +78,9 @@ SECTIONS['tomoscan'] = {
     'scan-type':{
         'default': '',
         'type': str,
-        'help': "For internal use to log the tomoscan status"},
+        'help': "Scan type",
+        'default' : "Single",
+        'choices': ['Single','Vertical', 'Horizontal', 'Mosaic', 'Energy', 'File', 'Helical']}, 
         }
 
 SECTIONS['in-situ'] = {
@@ -147,13 +155,30 @@ SECTIONS['energy'] = {
         'help': "Txt file with PV values corresponding to optics positions for the second energy"},    
     }
 
+SECTIONS['file'] = {
+    'num-scans': {
+        'default': 10,
+        'type': util.positive_int,
+        'help': "Horizontal scan position"},
+    'sample-x': {
+        'default': 0,
+        'type': float,
+        'help': "Horizontal scan position"},
+    'sample-y': {
+        'default': 0,
+        'type': float,
+        'help': "Vertical scan position"},
+    }
+
+INIT_PARAMS = ('tomoscan', 'file')
 SINGLE_SCAN_PARAMS = ('tomoscan', 'in-situ')
 VERTICAL_SCAN_PARAMS = SINGLE_SCAN_PARAMS + ('vertical',)
 HORIZONTAL_SCAN_PARAMS = SINGLE_SCAN_PARAMS + ('horizontal',)
 MOSAIC_SCAN_PARAMS = SINGLE_SCAN_PARAMS + ('vertical', 'horizontal')
 ENERGY_SCAN_PARAMS = SINGLE_SCAN_PARAMS + ('energy',)
+FILE_SCAN_PARAMS = SINGLE_SCAN_PARAMS + ('file', )
 
-NICE_NAMES = ('General', 'Tomoscan', 'In-situ Scans', 'Vertical Scan', "Horizonatal Scan")
+NICE_NAMES = ('General', 'Tomoscan', 'In-situ Scans', 'Vertical Scan', "Horizonatal Scan", "Energy", "File")
 
 def get_config_name():
     """Get the command line --config option."""


### PR DESCRIPTION
* added PV to store scan type and flip&stitch status

* addressed #143 FlatFieldValue is missing from tomoscan.adl

* added support for scanning to tomoscan cli to run scans from a list of X-Y sample position

* added json file error handling

* moved ScanType and FlipStitch PVs to the base class

* added ScanType and Flip&Stitch for 32-ID and 7-BM

* added support for an arbitrary number of scans. Each scan parameter can be uniquely customized by editing a json file.

* added support for an arbitrary number of scans. Each scan parameter can be uniquely customized by editing a json file.

* added support for an arbitrary number of scans. Each scan parameter can be uniquely customized by editing a json file.

* added helical ScanType

* added helical ScanType

* ScanType is now in the base class

* standardized scanType labels